### PR TITLE
[feature] atari-test.epfl.ch

### DIFF
--- a/ansible/roles/atari-vm/templates/traefik-dynamic.yml
+++ b/ansible/roles/atari-vm/templates/traefik-dynamic.yml
@@ -9,7 +9,7 @@ http:
       rule: Host(`itsidevfsd0024.xaas.epfl.ch`) && (PathPrefix(`/api`) || PathPrefix(`/dashboard`))
       service: api@internal
     atari:
-      rule: Host(`itsidevfsd0024.xaas.epfl.ch`)
+      rule: "Host(`itsidevfsd0024.xaas.epfl.ch`) || Host(`atari-test.epfl.ch`)"
       tls: {}
       service: atari
       entrypoints:


### PR DESCRIPTION
Update traefik-dynamic.yml configuration in order that CNAME atari-test respond.